### PR TITLE
Add standalone React expense tracker demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Ứng dụng quản lý chi tiêu đơn giản
+
+Ứng dụng React một trang giúp ghi nhận chi tiêu hằng ngày, tổng hợp báo cáo theo tháng và mô phỏng các tính năng phân tích nâng cao như OCR hóa đơn và dự đoán thói quen chi tiêu.
+
+## Cách sử dụng
+
+1. Mở file `index.html` bằng trình duyệt.
+2. Sử dụng biểu mẫu để nhập chi tiêu mới:
+   - Nhập đầy đủ ngày, mô tả, số tiền và ghi chú (nếu có).
+   - Hoặc sử dụng ô **Nhập nhanh** để dán câu văn tự nhiên, ví dụ: `Hôm nay mua cà phê 50k, ăn trưa 100k`.
+3. Ứng dụng sẽ hiển thị tổng chi tiêu, thống kê theo tháng và các gợi ý nâng cao.
+
+## Tính năng chính
+
+- Lưu dữ liệu cục bộ bằng `localStorage`.
+- Gợi ý hạng mục chi tiêu dựa trên từ khóa phổ biến.
+- Báo cáo tháng với tổng tiền, số giao dịch và phân bổ theo hạng mục.
+- Phân tích nâng cao (minh họa) gồm OCR hóa đơn và dự đoán chi tiêu tháng tới.
+
+## Phát triển thêm
+
+- Tích hợp dịch vụ OCR thực tế (ví dụ Tesseract.js) để đọc ảnh hóa đơn.
+- Kết nối mô hình máy học để dự báo ngân sách theo thói quen.
+- Xuất dữ liệu ra CSV hoặc Google Sheets.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quản lý chi tiêu</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="src/app.jsx"></script>
+  </body>
+</html>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,0 +1,430 @@
+const { useState, useMemo, useEffect } = React;
+
+const STORAGE_KEY = "stk-expenses-v1";
+
+const SAMPLE_EXPENSES = [
+  {
+    id: crypto.randomUUID(),
+    description: "Cà phê sáng",
+    amount: 45000,
+    date: new Date().toISOString().slice(0, 10),
+    category: "Đồ uống",
+    note: "Latte ở quán quen",
+  },
+  {
+    id: crypto.randomUUID(),
+    description: "Ăn trưa",
+    amount: 95000,
+    date: new Date().toISOString().slice(0, 10),
+    category: "Ăn uống",
+    note: "Cơm văn phòng",
+  },
+  {
+    id: crypto.randomUUID(),
+    description: "Grab đi làm",
+    amount: 68000,
+    date: new Date(Date.now() - 86400000).toISOString().slice(0, 10),
+    category: "Di chuyển",
+    note: "",
+  },
+];
+
+const CATEGORY_KEYWORDS = [
+  { category: "Ăn uống", patterns: ["ăn", "cơm", "phở", "bún", "trưa", "tối"] },
+  { category: "Đồ uống", patterns: ["cà phê", "trà", "nước", "milk", "cafe"] },
+  { category: "Di chuyển", patterns: ["grab", "taxi", "bus", "xăng", "vé", "tàu"] },
+  { category: "Mua sắm", patterns: ["mua", "shop", "áo", "quần", "điện"] },
+  { category: "Giải trí", patterns: ["xem phim", "netflix", "game", "nhạc"] },
+];
+
+function formatCurrency(amount) {
+  return amount.toLocaleString("vi-VN", {
+    style: "currency",
+    currency: "VND",
+    maximumFractionDigits: 0,
+  });
+}
+
+function inferCategory(description) {
+  const normalized = description.toLowerCase();
+  for (const { category, patterns } of CATEGORY_KEYWORDS) {
+    if (patterns.some((pattern) => normalized.includes(pattern))) {
+      return category;
+    }
+  }
+  return "Khác";
+}
+
+function parseAmount(value) {
+  if (!value) return 0;
+  const cleaned = value
+    .toString()
+    .toLowerCase()
+    .replace(/[.,]/g, "")
+    .trim();
+
+  const match = cleaned.match(/(\d+)(k|ngan|ngàn|000)?/);
+  if (!match) return Number.parseInt(cleaned, 10) || 0;
+
+  const amount = Number.parseInt(match[1], 10);
+  const hasK = match[2];
+  return hasK ? amount * 1000 : amount;
+}
+
+function parseQuickEntry(text) {
+  if (!text) return null;
+  const amountMatch = text.match(/(\d+[.,]?\d*)(\s?k|\s?ng[àa]n)?/i);
+  const amount = amountMatch ? parseAmount(amountMatch[0]) : 0;
+  const description = amountMatch
+    ? text.replace(amountMatch[0], "").replace(/[,.;-]+$/, "").trim()
+    : text.trim();
+
+  return {
+    description: description || "Chi tiêu chưa đặt tên",
+    amount,
+    note: text.trim(),
+  };
+}
+
+function generateMonthlyReport(expenses) {
+  const report = expenses.reduce((acc, expense) => {
+    const month = expense.date.slice(0, 7);
+    if (!acc[month]) {
+      acc[month] = { total: 0, transactions: 0, categories: {} };
+    }
+    acc[month].total += expense.amount;
+    acc[month].transactions += 1;
+    acc[month].categories[expense.category] =
+      (acc[month].categories[expense.category] || 0) + expense.amount;
+    return acc;
+  }, {});
+
+  return Object.entries(report)
+    .map(([month, data]) => ({ month, ...data }))
+    .sort((a, b) => (a.month < b.month ? 1 : -1));
+}
+
+function generateInsights(expenses) {
+  if (expenses.length === 0) {
+    return {
+      topCategory: null,
+      averageDaily: 0,
+      predictedNextMonth: 0,
+      streak: 0,
+    };
+  }
+
+  const totalsByCategory = expenses.reduce((acc, expense) => {
+    acc[expense.category] = (acc[expense.category] || 0) + expense.amount;
+    return acc;
+  }, {});
+
+  const [topCategory, topTotal] = Object.entries(totalsByCategory).reduce(
+    (max, entry) => (entry[1] > max[1] ? entry : max),
+    ["", 0],
+  );
+
+  const days = new Set(expenses.map((expense) => expense.date)).size;
+  const averageDaily = expenses.reduce((sum, e) => sum + e.amount, 0) / days;
+
+  const monthlyReport = generateMonthlyReport(expenses);
+  const lastTwoMonths = monthlyReport.slice(0, 2);
+  const predictedNextMonth =
+    lastTwoMonths.reduce((sum, month) => sum + month.total, 0) /
+    Math.max(lastTwoMonths.length, 1);
+
+  // simple streak: count days with spending in a row up to today
+  const today = new Date().toISOString().slice(0, 10);
+  let streak = 0;
+  const expenseByDate = expenses.reduce((acc, expense) => {
+    acc[expense.date] = (acc[expense.date] || 0) + expense.amount;
+    return acc;
+  }, {});
+
+  let cursor = new Date(today);
+  while (expenseByDate[cursor.toISOString().slice(0, 10)]) {
+    streak += 1;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+
+  return {
+    topCategory: topCategory ? { name: topCategory, total: topTotal } : null,
+    averageDaily,
+    predictedNextMonth,
+    streak,
+  };
+}
+
+function App() {
+  const [expenses, setExpenses] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed;
+        }
+      }
+    } catch (error) {
+      console.warn("Không thể đọc dữ liệu đã lưu", error);
+    }
+    return SAMPLE_EXPENSES;
+  });
+
+  const [form, setForm] = useState({
+    date: new Date().toISOString().slice(0, 10),
+    description: "",
+    amount: "",
+    note: "",
+    quickEntry: "",
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(expenses));
+  }, [expenses]);
+
+  const total = useMemo(
+    () => expenses.reduce((sum, expense) => sum + expense.amount, 0),
+    [expenses],
+  );
+
+  const monthlyReport = useMemo(
+    () => generateMonthlyReport(expenses),
+    [expenses],
+  );
+
+  const insights = useMemo(() => generateInsights(expenses), [expenses]);
+
+  function handleChange(event) {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    let payload;
+
+    if (form.quickEntry.trim()) {
+      payload = parseQuickEntry(form.quickEntry.trim());
+    } else {
+      payload = {
+        description: form.description.trim() || "Chi tiêu chưa đặt tên",
+        amount: parseAmount(form.amount),
+        note: form.note.trim(),
+      };
+    }
+
+    if (!payload || !payload.amount) {
+      alert("Vui lòng nhập số tiền hợp lệ");
+      return;
+    }
+
+    const date = form.date || new Date().toISOString().slice(0, 10);
+    const category = inferCategory(payload.description);
+
+    const newExpense = {
+      id: crypto.randomUUID(),
+      description: payload.description,
+      amount: payload.amount,
+      date,
+      category,
+      note: payload.note || "",
+    };
+
+    setExpenses((prev) => [newExpense, ...prev]);
+    setForm((prev) => ({
+      ...prev,
+      description: "",
+      amount: "",
+      note: "",
+      quickEntry: "",
+    }));
+  }
+
+  function handleDelete(id) {
+    setExpenses((prev) => prev.filter((expense) => expense.id !== id));
+  }
+
+  return (
+    <div className="container">
+      <h1>Trợ lý quản lý chi tiêu</h1>
+
+      <section className="card">
+        <h2>Thêm chi tiêu mới</h2>
+        <form onSubmit={handleSubmit} className="form-grid">
+          <div>
+            <label htmlFor="date">Ngày</label>
+            <input
+              id="date"
+              name="date"
+              type="date"
+              value={form.date}
+              onChange={handleChange}
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="description">Mô tả</label>
+            <input
+              id="description"
+              name="description"
+              placeholder="Ví dụ: Ăn trưa"
+              value={form.description}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="amount">Số tiền (VND)</label>
+            <input
+              id="amount"
+              name="amount"
+              placeholder="Ví dụ: 120000"
+              value={form.amount}
+              onChange={handleChange}
+              inputMode="numeric"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="note">Ghi chú</label>
+            <textarea
+              id="note"
+              name="note"
+              placeholder="Tùy chọn"
+              value={form.note}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div style={{ gridColumn: "1 / -1" }}>
+            <label htmlFor="quickEntry">Nhập nhanh (ngôn ngữ tự nhiên)</label>
+            <textarea
+              id="quickEntry"
+              name="quickEntry"
+              placeholder="Ví dụ: Hôm nay mua cà phê 50k, ăn trưa 100k"
+              value={form.quickEntry}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div style={{ gridColumn: "1 / -1" }}>
+            <button type="submit">Lưu chi tiêu</button>
+          </div>
+        </form>
+      </section>
+
+      <section className="card">
+        <h2>Tổng quan</h2>
+        <p>
+          <span className="badge">Tổng chi tiêu</span> {formatCurrency(total)}
+        </p>
+        <p>
+          Trung bình mỗi ngày: {formatCurrency(Math.round(insights.averageDaily || 0))}
+        </p>
+        {insights.topCategory ? (
+          <p>
+            Hạng mục chi nhiều nhất: <strong>{insights.topCategory.name}</strong> ({formatCurrency(insights.topCategory.total)})
+          </p>
+        ) : (
+          <p className="empty-state">Chưa có dữ liệu đủ để phân tích</p>
+        )}
+        <p>Chuỗi ngày chi tiêu liên tiếp: {insights.streak} ngày</p>
+      </section>
+
+      <section className="card">
+        <h2>Danh sách chi tiêu gần đây</h2>
+        {expenses.length === 0 ? (
+          <p className="empty-state">Chưa có chi tiêu nào, hãy thêm ghi nhận đầu tiên!</p>
+        ) : (
+          <div className="expense-list">
+            {expenses.map((expense) => (
+              <article key={expense.id} className="expense-item">
+                <div>
+                  <strong>{expense.description}</strong>
+                  <div className="meta">
+                    {formatCurrency(expense.amount)} · {expense.category}
+                  </div>
+                  <div className="meta">
+                    {new Date(expense.date).toLocaleDateString("vi-VN")}
+                    {expense.note ? ` · ${expense.note}` : ""}
+                  </div>
+                </div>
+                <button type="button" onClick={() => handleDelete(expense.id)}>
+                  Xóa
+                </button>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="card">
+        <h2>Báo cáo theo tháng</h2>
+        {monthlyReport.length === 0 ? (
+          <p className="empty-state">Chưa có dữ liệu để lập báo cáo.</p>
+        ) : (
+          <div className="report-grid">
+            {monthlyReport.map((month) => (
+              <div key={month.month} className="report-card">
+                <h3>
+                  {new Date(month.month + "-01").toLocaleDateString("vi-VN", {
+                    month: "long",
+                    year: "numeric",
+                  })}
+                </h3>
+                <p>Tổng: {formatCurrency(month.total)}</p>
+                <p>{month.transactions} giao dịch</p>
+                <ul className="analysis-list">
+                  {Object.entries(month.categories).map(([category, value]) => (
+                    <li key={category}>
+                      {category}: {formatCurrency(value)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="card">
+        <h2>Phân tích nâng cao</h2>
+        <div className="advanced-section">
+          <div className="report-card">
+            <h3>OCR hóa đơn (minh họa)</h3>
+            <p>
+              Tải ảnh hóa đơn và hệ thống sẽ tự động nhận diện số tiền, nhà cung
+              cấp và hạng mục chi tiêu bằng công nghệ OCR. (Tính năng demo: sử
+              dụng ghi chú để mô tả nội dung hóa đơn).
+            </p>
+            <ul className="analysis-list">
+              <li>Nhận diện tổng tiền từ hình ảnh hóa đơn.</li>
+              <li>Gợi ý hạng mục dựa trên tên cửa hàng.</li>
+              <li>Trích xuất ngày giao dịch để lưu tự động.</li>
+            </ul>
+          </div>
+
+          <div className="report-card">
+            <h3>Dự đoán thói quen chi tiêu</h3>
+            <p>
+              Mô phỏng mô hình học máy: dự đoán chi tiêu tháng tới khoảng
+              {" "}
+              <strong>{formatCurrency(Math.round(insights.predictedNextMonth || 0))}</strong>
+              {" "}
+              dựa trên xu hướng 2 tháng gần nhất.
+            </p>
+            <p>
+              Gợi ý: thiết lập ngân sách theo tuần để kiểm soát dòng tiền tốt
+              hơn và đặt cảnh báo khi vượt ngưỡng.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,162 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7fb;
+  --card: #ffffffee;
+  --text: #1f2937;
+  --primary: #2563eb;
+  --border: #e5e7eb;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(135deg, #eef2ff, #f8fafc);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 32px 16px 64px;
+}
+
+h1 {
+  text-align: center;
+  font-weight: 700;
+  margin-bottom: 32px;
+}
+
+.card {
+  background: var(--card);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 20px;
+  margin-bottom: 16px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+input,
+textarea,
+select,
+button {
+  font: inherit;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 64px;
+}
+
+button {
+  background: var(--primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.2);
+}
+
+.expense-list {
+  display: grid;
+  gap: 12px;
+}
+
+.expense-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border: 1px dashed #cbd5f5;
+  padding: 12px;
+  border-radius: 12px;
+  background: white;
+}
+
+.expense-item strong {
+  display: block;
+  font-size: 16px;
+}
+
+.meta {
+  color: #64748b;
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+.report-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.report-card {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  background: white;
+}
+
+.report-card h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.advanced-section {
+  display: grid;
+  gap: 16px;
+}
+
+.analysis-list {
+  list-style: disc;
+  padding-left: 20px;
+  color: #1d4ed8;
+}
+
+.empty-state {
+  text-align: center;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .card {
+    padding: 18px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page React expense tracker that runs directly from index.html
- implement input form, quick-entry parser, monthly reporting, and insight widgets
- style the UI with a modern layout and document usage in the README

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68caf2b832548322852840920a08285a